### PR TITLE
fix lints and remove unneeded whitespace.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,148 +1,150 @@
 #![allow(dead_code)]
+#![warn(clippy::all, clippy::pedantic, clippy::nursery)]
+#![allow(clippy::missing_errors_doc, clippy::cast_possible_wrap)]
 
-extern crate serialport; 
+extern crate serialport;
 
-use std::error::Error; 
-use std::io::{self, BufRead, BufReader}; 
-use serialport::SerialPort;  
+use std::error::Error;
+use std::io::{self, BufRead, BufReader};
+use serialport::SerialPort; 
 
 /// Tries to read a raw QWORD from the given `port`.
-/// 
-/// This function gives no concern to endianness. 
+///
+/// This function gives no concern to endianness.
 pub fn read_qword_raw(port: &mut dyn SerialPort) -> Result<u64, io::Error> {
-    let mut buf = [0 as u8; 8]; 
+    let mut buf = [0_u8; 8];
     port.read_exact(&mut buf)?;
-    let qword_ptr: *const u64 = (&buf as *const u8).cast(); 
+    let qword_ptr: *const u64 = std::ptr::addr_of!(buf).cast();
     unsafe {
-        return Ok(*qword_ptr); 
+        Ok(*qword_ptr)
     }
 }
 
-/// Tries to read a raw QWORD from the given `port`, 
+/// Tries to read a raw QWORD from the given `port`,
 /// then converts it to the opposite endian.
-/// 
-/// Useful for, say, reading x86-based numeric values on an ARM machine. 
+///
+/// Useful for, say, reading x86-based numeric values on an ARM machine.
 pub fn read_qword_flipped_endian(port: &mut dyn SerialPort) -> Result<u64, io::Error> {
-    let mut buf = [0 as u8; 8]; 
-    port.read_exact(&mut buf)?; 
-    buf.reverse(); 
+    let mut buf = [0_u8; 8];
+    port.read_exact(&mut buf)?;
+    buf.reverse();
     unsafe {
-        return Ok(*(&buf as *const u8).cast()); 
+        Ok(*std::ptr::addr_of!(buf).cast())
     }
 }
 
 /// Tries to write a raw QWORD to the given `port`.
-/// 
-/// This function gives no concern to endianness. 
-pub fn write_qword_raw(port: &mut dyn SerialPort, ref val: u64) -> Result<(), io::Error> {
-    let buf_ptr: *const [u8; 8] = (val as *const u64).cast(); 
+///
+/// This function gives no concern to endianness.
+pub fn write_qword_raw(port: &mut dyn SerialPort, val: u64) -> Result<(), io::Error> {
+    let buf_ptr: *const [u8; 8] = (val as *const u64).cast();
     unsafe {
-        return port.write_all(&*buf_ptr); 
+        port.write_all(&*buf_ptr)
     }
 }
 
 /// Tries to write a QWORD with flipped endian to the given `port`.
-/// 
+///
 /// Useful for, say, writing x86-based numerics to ARM machines.
-pub fn write_qword_flipped_endian(port: &mut dyn SerialPort, ref mut val: u64) -> Result<(), io::Error> {
-    let buf_ptr: *mut [u8; 8] = (val as *mut u64).cast(); 
+pub fn write_qword_flipped_endian(port: &mut dyn SerialPort, val: u64) -> Result<(), io::Error> {
+    let buf_ptr: *mut [u8; 8] = (val as *mut u64).cast();
     unsafe {
-        let buf: &mut [u8; 8] = &mut *buf_ptr; 
+        let buf: &mut [u8; 8] = &mut *buf_ptr;
         buf.reverse();
-        return port.write_all(buf); 
+        port.write_all(buf)
     }
 }
 
-/// Tries to read a raw QWORD from the given `port` and converts it into `i64`. 
-/// 
-/// This function gives no concern to endianness. 
+/// Tries to read a raw QWORD from the given `port` and converts it into `i64`.
+///
+/// This function gives no concern to endianness.
 pub fn read_i64_raw(port: &mut dyn SerialPort) -> Result<i64, io::Error> {
     Ok(read_qword_raw(port)? as i64)
 }
 
-/// Tries to read a raw DWORD from the given `port`. 
-/// 
-/// This function gives no concern to endianness. 
+/// Tries to read a raw DWORD from the given `port`.
+///
+/// This function gives no concern to endianness.
 pub fn read_dword_raw(port: &mut dyn SerialPort) -> Result<u32, io::Error> {
-    let mut buf = [0 as u8; 4]; 
+    let mut buf = [0_u8; 4];
     port.read_exact(&mut buf)?;
-    let dword_ptr: *const u32 = (&buf as *const u8).cast();
+    let dword_ptr: *const u32 = std::ptr::addr_of!(buf).cast();
     unsafe {
-        return Ok(*dword_ptr); 
+        Ok(*dword_ptr)
     }
 }
 
-/// Tries to read a raw DWORD from the given `port`, 
-/// then converts it to the opposite endian. 
-/// 
-/// Useful for, say, reading x86-based numeric values on an ARM machine. 
+/// Tries to read a raw DWORD from the given `port`,
+/// then converts it to the opposite endian.
+///
+/// Useful for, say, reading x86-based numeric values on an ARM machine.
 pub fn read_dword_flipped_endian(port: &mut dyn SerialPort) -> Result<u32, io::Error> {
-    let mut buf = [0 as u8; 4]; 
-    port.read_exact(&mut buf)?; 
-    buf.reverse(); 
+    let mut buf = [0_u8; 4];
+    port.read_exact(&mut buf)?;
+    buf.reverse();
     unsafe {
-        return Ok(*(&buf as *const u8).cast()); 
+        Ok(*std::ptr::addr_of!(buf).cast())
     }
 }
 
-/// Tries to write a raw DWORD to the given `port`. 
-/// 
-/// This function gives no concern to endianness. 
-pub fn write_dword_raw(port: &mut dyn SerialPort, ref val: u32) -> Result<(), io::Error> {
-    let buf_ptr: *const [u8; 4] = (val as *const u32).cast(); 
+/// Tries to write a raw DWORD to the given `port`.
+///
+/// This function gives no concern to endianness.
+pub fn write_dword_raw(port: &mut dyn SerialPort, val: u32) -> Result<(), io::Error> {
+    let buf_ptr: *const [u8; 4] = (val as *const u32).cast();
     unsafe {
-        return port.write_all(&*buf_ptr); 
+        port.write_all(&*buf_ptr)
     }
 }
 
-/// Tries to write a DWORD with flipped endian to the given `port`. 
-/// 
-/// Useful for, say, writing x86-based numerics to ARM machines. 
-pub fn write_dword_flipped_endian(port: &mut dyn SerialPort, ref mut val: u32) -> Result<(), io::Error> {
-    let buf_ptr: *mut [u8; 4] = (val as *mut u32).cast(); 
+/// Tries to write a DWORD with flipped endian to the given `port`.
+///
+/// Useful for, say, writing x86-based numerics to ARM machines.
+pub fn write_dword_flipped_endian(port: &mut dyn SerialPort, val: u32) -> Result<(), io::Error> {
+    let buf_ptr: *mut [u8; 4] = (val as *mut u32).cast();
     unsafe {
         let buf: &mut [u8; 4] = &mut *buf_ptr;
-        buf.reverse(); 
-        return port.write_all(buf); 
+        buf.reverse();
+        port.write_all(buf)
     }
 }
 
-/// Tries to read a raw DWORD from the given `port` and converts it into `i64`. 
-/// 
-/// This function gives no concern to endianness. 
+/// Tries to read a raw DWORD from the given `port` and converts it into `i64`.
+///
+/// This function gives no concern to endianness.
 pub fn read_i32_raw(port: &mut dyn SerialPort) -> Result<i32, io::Error> {
     Ok(read_dword_raw(port)? as i32)
 }
 
-/// Tries to read a String from the given `port`. 
-/// 
+/// Tries to read a String from the given `port`.
+///
 /// ## Ok
-/// Owned `String` containing the sent text until and including `endbyte`. I don't make the rules. 
-/// 
+/// Owned `String` containing the sent text until and including `endbyte`. I don't make the rules.
+///
 /// ## Err
 /// - `io::Error` if cannot read from `port`.
 /// - `alloc::string::FromUtf8Error` if cannot parse `u8` buffer to `String`.
 pub fn read_string_until_byte(port: &mut dyn SerialPort, endbyte: u8) -> Result<String, Box<dyn Error>> {
-    let mut br = BufReader::new(port);  
+    let mut br = BufReader::new(port); 
     let mut buf: Vec<u8> = Vec::with_capacity(4096);
-    br.read_until(endbyte, &mut buf)?; 
-    return Ok(String::from_utf8(buf)?); 
+    br.read_until(endbyte, &mut buf)?;
+    Ok(String::from_utf8(buf)?)
 }
 
-/// Tries to write a string slice into the given `port`. 
+/// Tries to write a string slice into the given `port`.
 pub fn write_str_raw(port: &mut dyn SerialPort, str_to_write: &str) -> Result<(), io::Error> {
     port.write_all(str_to_write.as_bytes())
 }
 
 /// Tries to write a string slice into the given `port`, appending `endbyte` at behind.
 pub fn write_str_ends_with(
-    port: &mut dyn SerialPort, 
-    str_to_write: &str, 
+    port: &mut dyn SerialPort,
+    str_to_write: &str,
     endbyte: u8
 ) -> Result<(), io::Error> {
-    let endbyte_ptr: *const [u8; 1] = (&endbyte as *const u8).cast(); 
+    let endbyte_ptr: *const [u8; 1] = std::ptr::addr_of!(endbyte).cast();
     port.write_all(str_to_write.as_bytes())?;
     unsafe {
-        return port.write_all(&*endbyte_ptr); 
+        port.write_all(&*endbyte_ptr)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,67 +1,69 @@
 #![allow(dead_code)]
+#![warn(clippy::all, clippy::pedantic, clippy::nursery)]
 
-use std::io; 
-use std::io::Write; 
+use std::io;
+use std::io::Write;
 use std::time::Duration;
-use std::thread::sleep; 
+use std::thread::sleep;
 
-use serialport::{SerialPortType, SerialPort}; 
-use serial_communicator::*;
-use log::{error, info}; 
+use serialport::{SerialPortType, SerialPort};
+use serial_communicator::{read_string_until_byte, write_str_ends_with};
+use log::{error, info};
 
-mod util; 
+mod util;
 
-const DEFAULT_BAUD_RATE: u32 = 115200; 
-const HANDSHAKE_TXM: &str = "HELLO ARDUINO"; 
-const HANDSHAKE_RXM: &str = "HELLO RASPI"; 
+const DEFAULT_BAUD_RATE: u32 = 115_200;
+const HANDSHAKE_TXM: &str = "HELLO ARDUINO";
+const HANDSHAKE_RXM: &str = "HELLO RASPI";
 
-const NULL_TERM: u8 = 0x00; 
-const LF_TERM:   u8 = unsafe { *(&'\n' as *const char).cast() }; 
-const EOF_TERM:  u8 = 0x04; 
+const NULL_TERM: u8 = 0x00;
+const LF_TERM:   u8 = b'\n';
+const EOF_TERM:  u8 = 0x04;
 
-/// Tries to connect to the first *correctly set* Arduino connected via USB as `tty` device. 
-/// 
+/// Tries to connect to the first *correctly set* Arduino connected via USB as `tty` device.
+///
 /// ### Arguments
 /// - `baud_rate` for Arduino
-/// 
+///
 /// ### Returns
 /// - `Ok(port)` which encapsulates a dynamically dispatched `SerialPort` trait object.
-/// - `Err(io::Error)` which is of kind `io::ErrorKind::NotFound`, indicating that a suitable `tty` 
-///    device cannot be found. 
+/// - `Err(io::Error)` which is of kind `io::ErrorKind::NotFound`, indicating that a suitable `tty`
+///    device cannot be found.
 fn _find_arduino_serialport(baud_rate: u32) -> io::Result<Box<dyn SerialPort>> {
-    const _FN_NAME: &str = "[serial-communicator::_find_arduino_serialport]"; 
+    const _FN_NAME: &str = "[serial-communicator::_find_arduino_serialport]";
     stderrlog::new().module(module_path!()).init().unwrap();
 
-    let available_ports = serialport::available_ports()?; 
+    let available_ports = serialport::available_ports()?;
     for info in &available_ports {
         if let SerialPortType::UsbPort(_) = &info.port_type {
             // Do not check for metadata, which enables 3rd party boards to be used
             let port = serialport::new(&info.port_name, baud_rate)
                 .timeout(Duration::from_millis(100))
                 .open();
-            if let Err(_) = port { continue; } // Cannot open port 
-            let mut port = port.unwrap(); 
-            
+            if port.is_err() { continue; } // Cannot open port
+            let mut port = port.unwrap();
+           
             /* Handshake */
-            if let Ok(_) = serial_communicator::write_str_ends_with(
-                port.as_mut(), 
-                HANDSHAKE_TXM, 
-                LF_TERM 
-            ) { // => Can send
+            let res = serial_communicator::write_str_ends_with(
+                port.as_mut(),
+                HANDSHAKE_TXM,
+                LF_TERM
+            );
+            if res.is_ok() { // => Can send
                 match serial_communicator::read_string_until_byte(
-                    port.as_mut(), 
+                    port.as_mut(),
                     LF_TERM
                 ) {
                     Ok(msg) => {
                         // => Can receive -- Let the Arduino check for correctness too [TODO]
-                        let msg = &msg.as_bytes()[..msg.as_bytes().len() - 1]; 
+                        let msg = &msg.as_bytes()[..msg.as_bytes().len() - 1];
                         if msg == HANDSHAKE_RXM.as_bytes() {
                            // => Received correctly
-                           return Ok(port); 
+                           return Ok(port);
                         }
                         // => Received incorrectly (maybe change baud rate?)
-                        continue; 
-                    }, 
+                        continue;
+                    },
                     _ => // continue, // => Cannot receive
                     return Ok(port), // Currently no handshake impl, return as well
                 }
@@ -70,85 +72,85 @@ fn _find_arduino_serialport(baud_rate: u32) -> io::Result<Box<dyn SerialPort>> {
     }
 
     return Err(io::Error::new(
-        io::ErrorKind::NotFound, 
-        format!("{} Cannot find Arduino ttyusb device at baud rate `{}`", _FN_NAME, baud_rate)
-    )); 
+        io::ErrorKind::NotFound,
+        format!("{_FN_NAME} Cannot find Arduino ttyusb device at baud rate `{baud_rate}`")
+    ));
 }
 
-/// Loops over four things: 
+/// Loops over four things:
 /// - Wait read from stdin (e.g., move)
-/// - send to arduino 
+/// - send to arduino
 /// - wait read from arduino (e.g., reed switches)
 /// - send to stdout
-/// 
-/// That's it. Returns whenever stdin reaches EOF e.g., after parent proc closes pipe. 
-/// 
+///
+/// That's it. Returns whenever stdin reaches EOF e.g., after parent proc closes pipe.
+///
 /// ### TODO
-/// - Arduino-side software needs to implement handshake abilities. 
-/// - For now `main` loops over four things. Ideally (to better fit `master-program::main` control 
-///   loop) `main` could instead cache over reads and writes and return/send values on-demand, as 
+/// - Arduino-side software needs to implement handshake abilities.
+/// - For now `main` loops over four things. Ideally (to better fit `master-program::main` control
+///   loop) `main` could instead cache over reads and writes and return/send values on-demand, as
 ///   sent alongside stdin. The current impl is much less messy though.
-/// - `_find_arduino_serialport` can maybe be expanded to accept multiple baud rates for handshaking 
-///   purposes. This is not too high of a concern, though. 
-/// - It works on real Arduino (ofc.) but buffering needs work maybe -- this can also affect 
+/// - `_find_arduino_serialport` can maybe be expanded to accept multiple baud rates for handshaking
+///   purposes. This is not too high of a concern, though.
+/// - It works on real Arduino (ofc.) but buffering needs work maybe -- this can also affect
 ///   handshaking impl.
 fn main() {
-    const _FN_NAME: &str = "[serial-communicator::main]"; 
+    const _FN_NAME: &str = "[serial-communicator::main]";
 
     /* 1. Find Arduino device */
     let mut arduino_port = match _find_arduino_serialport(DEFAULT_BAUD_RATE) {
-        Ok(p) => p, 
+        Ok(p) => p,
         Err(e) => {
             // => Cannot find arduino ttyusb @ given baud rate, return
-            error!("{}", e); 
-            return; 
+            error!("{}", e);
+            return;
         }
-    }; 
-    let mut buffer: String = String::with_capacity(4096); 
-    let mut eof_flag = false; 
+    };
+    let mut buffer: String = String::with_capacity(4096);
+    let mut eof_flag = false;
 
     sleep(Duration::from_secs(3));
 
     loop {
         /* 2. Read from `stdin` and re-send to Arduino */
-        buffer.clear(); 
+        buffer.clear();
         match io::stdin().read_line(&mut buffer) {
             Ok(0) => {
                 // => EOF reached, send once and close
-                info!("{} EOF reached at stdin", _FN_NAME); 
-                eof_flag = true; 
-            }, 
-            Ok(_) => (), 
+                info!("{} EOF reached at stdin", _FN_NAME);
+                eof_flag = true;
+            },
+            Ok(_) => (),
             Err(e) => {
-                error!("{} Unexpected error when reading from stdin: \n{:#?}", _FN_NAME, e); 
-                return; 
-            } 
+                error!("{} Unexpected error when reading from stdin: \n{:#?}", _FN_NAME, e);
+                return;
+            }
         };
         match write_str_ends_with(
-            arduino_port.as_mut(), 
-            &buffer, 
+            arduino_port.as_mut(),
+            &buffer,
             LF_TERM
         ) {
-            Ok(_) => (), 
+            Ok(_) => (),
             Err(e) => {
-                error!("{} Unexpected error when sending to arduino tty: \n{:#?}", _FN_NAME, e); 
-                return; 
+                error!("{} Unexpected error when sending to arduino tty: \n{:#?}", _FN_NAME, e);
+                return;
             }
         }
 
         /* 3. Wait read on Arduino, send to `stdout` */
         match read_string_until_byte(arduino_port.as_mut(), LF_TERM) {
-            Ok(s) => 
+            Ok(s) =>
             if let Err(e) = io::stdout().write_all(&s.as_bytes()[0..s.len() - 1]) {
-                error!("{} Unexpected error when writing to stdout: \n{:#?}", _FN_NAME, e); 
-                return; 
-            }, 
+                error!("{} Unexpected error when writing to stdout: \n{:#?}", _FN_NAME, e);
+                return;
+            },
             Err(e) => {
-                error!("{} Unexpected error when reading from arduino tty: \n{:#?}", _FN_NAME, e); 
-                return; 
+                error!("{} Unexpected error when reading from arduino tty: \n{:#?}", _FN_NAME, e);
+                return;
             }
         }
-        
+       
         if eof_flag { return; }
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,12 +2,10 @@
 pub fn subslice_of<T>(small: &[T], large: &[T]) -> bool 
 where T: PartialEq {
     let window_size = small.len(); 
-    if window_size > large.len() {
-        panic!("[util::subslice_of] `small` longer than `large`")
-    }
+    assert!(window_size <= large.len(), "[util::subslice_of] `small` longer than `large`");
     for i in 0..=large.len() - window_size {
         let window = &large[i..(i + window_size)]; 
         if window == small { return true; }
     }
-    return false;
+    false
 }


### PR DESCRIPTION
This PR does only two things - remove trailing whitespace and mechanically apply the lints suggested by `rustc` and `clippy`. No functional change.